### PR TITLE
feat: replace '() => any' type with 'Function'

### DIFF
--- a/src/transformer/function.ts
+++ b/src/transformer/function.ts
@@ -13,7 +13,7 @@ const parser: Parser<LinkSchema> = (schema, options) => {
   } = schema;
   return {
     instanceOf: 'Function',
-    tsType: '(() => any)',
+    tsType: 'Function',
     ...(description ? { description } : {})
   }
 }


### PR DESCRIPTION
When there are parameters, the '() => any' type does not meet the type requirements.